### PR TITLE
Fix crate misspelling and update smooth-bevy-cameras

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ ilattice = { git = "https://github.com/bonsairobo/ilattice-rs", rev = "8c9ebdefa
 
 [dev-dependencies]
 bevy = "0.9"
-smooth-bevy-cameras = "0.6"
+smooth-bevy-cameras = "0.7"

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -173,5 +173,6 @@ fn spawn_scene(
             },
             Vec3::new(12.0, 12.0, 12.0),
             Vec3::new(0., 0., 0.),
+            Vec3::Y
         ));
 }

--- a/examples/render.rs
+++ b/examples/render.rs
@@ -5,7 +5,7 @@ use bevy::{
 };
 use glam::{Vec3, Vec3A};
 use ilattice::prelude::Extent;
-use multires_dual_contour::{
+use octree_dual_contour::{
     central_gradient, repair_sharp_normals, sdf_primitives::*, CellOctree, MeshVertexId,
 };
 use smooth_bevy_cameras::{controllers::fps::*, LookTransformPlugin};


### PR DESCRIPTION
Hello, first of all I just wanted to say that this looks very promising for the future.
In this PR I fixed a misspelling of crate that was preventing the example from compiling.
I also updated smooth-bevy-cameras to version 0.7.

It might also be a good idea to update the various small crates you have written to the new version 0.23 of glam.